### PR TITLE
Update components/ERestController.php

### DIFF
--- a/components/ERestController.php
+++ b/components/ERestController.php
@@ -438,7 +438,7 @@ class ERestController extends Controller
     return false;
   }
 
-  public function outputHelper($message, $results, $totalCount=1)
+  public function outputHelper($message, $results, $totalCount=0)
   {
     $this->renderJson(array('success'=>true, 'message'=>$message, 'data'=>array('totalCount'=>$totalCount, lcfirst(get_class($this->model))=>$this->allToArray($results))));
   }


### PR DESCRIPTION
I do not undurstand why default value set 1. If query return 0 rows result response is wrong. Example {"success":true,"message":"Record Retrieved Successfully","data":{"totalCount":1,"goodGroup":[]}}
