### PR TITLE
add operators in filter

### DIFF
--- a/components/ERestHelperScopes.php
+++ b/components/ERestHelperScopes.php
@@ -64,7 +64,7 @@ class ERestHelperScopes extends CActiveRecordBehavior {
                 $cType = $this->getFilterCType($field);
 
                 if (array_key_exists('operator', $filterItem) || is_array($value)) {
-                    if (is_array($value)) {
+                    if (!array_key_exists('operator', $filterItem)) {
                         $operator = 'in';
                     } else {
                         $operator = strtolower($filterItem['operator']);
@@ -74,9 +74,10 @@ class ERestHelperScopes extends CActiveRecordBehavior {
                         case 'in':
                             $paramsStr = '';
                             foreach ((array) $value as $index => $item) {
+                                $paramsStr.= (empty($paramsStr)) ? '' : ', ';
                                 $params[(":" . $prop . '_' . $index)] = $item;
+                                $paramsStr.= (":" . $prop . '_' . $index);
                             }
-                            $paramsStr = implode(', ', array_keys($params));
 
                             $compare = " " . strtoupper($operator) . " ({$paramsStr})";
                             break;


### PR DESCRIPTION
Add filter oprators for using '<', '<=', '>', '>=', '<>', 'in', 'not in' and 'like' in filter.

Example :
filter = [
    {"property": "id", "value" : 50, "operator": ">="}
    , {"property": "user_id", "value" : [1, 5, 10, 14], "operator": "in"}
    , {"property": "state", "value" : ["save", "deleted"], "operator": "not in"}
    , {"property": "date", "value" : "2013-01-01", "operator": ">="}
    , {"property": "date", "value" : "2013-01-31", "operator": "<="}
    , {"property": "type", "value" : 2, "operator": "!="}
]
result = 
(
    t.id >= :id0
    AND t.user_id IN (:user_id0_0, :user_id0_1, :user_id0_2, :user_id0_3)
    AND t.state NOT IN (:state0_0, :state0_1)
    AND t.date >= :date0
    AND t.date <= :date1
    AND t.type <> :type0
)
