### PR TITLE
The property developmentFlag was true by default, could be YII_DEBUG?

### DIFF
--- a/components/ERestController.php
+++ b/components/ERestController.php
@@ -15,7 +15,7 @@ class ERestController extends Controller
 	public $restSort = array();
 	public $restLimit = 100; // Default limit
 	public $restOffset = 0; //Default Offset
-	public $developmentFlag = true; //When set to `false' 500 erros will not return detailed messages.
+	public $developmentFlag = YII_DEBUG; //When set to `false' 500 erros will not return detailed messages.
 	protected $httpsOnly= FALSE; // Setting this variable to true allows the service to be used only via https
 	//Auto will include all relations 
 	//FALSE will include no relations in response


### PR DESCRIPTION
Hello.

I think that ERestController->$developmentFlag must be YII_DEBUG by default.
Thanks you for your work.

Greetings.
