### PR TITLE
Rest scenario wasn't being used on a view

### DIFF
--- a/components/ERestController.php
+++ b/components/ERestController.php
@@ -16,6 +16,7 @@ class ERestController extends Controller
 
     //By supplying a scenario you can determine which fields are included in a request
 	public $restScenario = 'rest';
+    public $restIncludeNested = true;
 	public $restLimit = 100; // Default limit
 	public $restOffset = 0; //Default Offset
 	public $developmentFlag = YII_DEBUG; //When set to `false' 500 errors will not return detailed messages.
@@ -53,6 +54,9 @@ class ERestController extends Controller
 
 		if(isset($_GET['scenario']))
 			$this->restScenario = $_GET['scenario'];
+
+        if(isset($_GET['NoNested']))
+            $this->restIncludeNested = false;
 
 		return parent::beforeAction($event);
 	}
@@ -720,7 +724,7 @@ class ERestController extends Controller
 	 */ 
 	public function doRestView($id)
 	{
-		$model = $this->loadOneModel($id);
+		$model = $this->loadOneModel($id,$this->restIncludeNested);
 		
 		if(is_null($model))
 		{


### PR DESCRIPTION
 $scenario was being used instead of $restScenario.  This means even if you passed in a scenario it always used the default 'rest'
