### PR TITLE
add emptyParent flag passing to custom delete, get and put methods

### DIFF
--- a/components/ERestController.php
+++ b/components/ERestController.php
@@ -268,7 +268,7 @@ class ERestController extends Controller
 				//if the $id is not numeric and var + var2 are not set
 				//we are assume that the client is attempting to call a custom method
 				//There may optionaly be a second param `$var` passed in the url
-				$this->triggerCustomRestGet(ucFirst($id), array($var, $var2));
+				$this->triggerCustomRestGet(ucFirst($id), array($var, $var2, 'emptyParent' => true));
 			}
 		}
 	}
@@ -295,7 +295,7 @@ class ERestController extends Controller
 			} 
 		}
 		else
-			$this->triggerCustomRestPut($id, array($var, $var2));
+			$this->triggerCustomRestPut($id, array($var, $var2, 'emptyParent' => true));
 	}
 	
 
@@ -345,7 +345,7 @@ class ERestController extends Controller
 		}
 		else
 		{
-			$this->triggerCustomDelete($id, array($var, $var2));
+			$this->triggerCustomDelete($id, array($var, $var2, 'emptyParent' => true));
 		}
 	}
 


### PR DESCRIPTION
To distinct whether the url was /api/controller/customMethod/id or /api/controller/id/customMethod in custom methods

Maybe not the best solution. Alternative solution of adding a new method renders the extension cumbersome and brings in complication. Maybe indexing the values in the array is better.
