### PR TITLE
Update ERestJSONOutputWidget.php

### DIFF
--- a/starship/RestfullYii/widgets/ERestJSONOutputWidget.php
+++ b/starship/RestfullYii/widgets/ERestJSONOutputWidget.php
@@ -226,7 +226,7 @@ class ERestJSONOutputWidget extends CWidget {
 					if (!$this->propertyIsVisable($property, $relation)) {
 							continue;
 					}
-					if($this->isBinary($schema->columns[$property]->dbType, $value)) {
+					if(array_key_exists($property, $schema->columns) and $this->isBinary($schema->columns[$property]->dbType, $value)) {
 						$value =  bin2hex($value);
 					}
 					$model_as_array[$property] = $value;


### PR DESCRIPTION
Fix check for virtual attributes.

In last commit, you add this:
https://github.com/evan108108/RESTFullYii/blob/217185696a9530885ad29ccb3b6b54d4c83f24aa/starship/RestfullYii/widgets/ERestJSONOutputWidget.php#L229

However, in my model, I have created some virtual attributes that are present only if application was in REST mode. So I add the check you can see in this PR.

Tested and work!
