### PR TITLE
Added support for modules

### DIFF
--- a/starship/RestfullYii/config/routes.php
+++ b/starship/RestfullYii/config/routes.php
@@ -46,7 +46,11 @@ return [
     ['<controller>/REST.OPTIONS', 'pattern'=>'api/<controller:\w+>/<id:\w*>/<param1:\w*>', 'verb'=>'OPTIONS'],
     ['<controller>/REST.OPTIONS', 'pattern'=>'api/<controller:\w+>/<id:\w*>/<param1:\w*>/<param2:\w*>', 'verb'=>'OPTIONS'],
 
-    
+	'<module:\w+>/<controller:\w+>/<id:\d+>'=>'<module>/<controller>/view',
+	'<module:\w+>/<controller:\w+>/<action:\w+>/<id:\d+>'=>'<module>/<controller>/<action>',
     '<module:\w+>/<controller:\w+>/<action:\w+>'=>'<module>/<controller>/<action>',
+
+	'<controller:\w+>/<id:\d+>'=>'<controller>/view',
+	'<controller:\w+>/<action:\w+>/<id:\d+>'=>'<controller>/<action>',
     '<controller:\w+>/<action:\w+>'=>'<controller>/<action>',
 ];


### PR DESCRIPTION
Typically a module route is defined as "/module/controller/action". So, for API, we make it "/api/module/controller" (the action is anyways the verb)

We could not include the following two lines because it can potentially cause ambiguity:

```
'<module:\w+>/<controller:\w+>/<id:\d+>'=>'<module>/<controller>/view',
'<controller:\w+>/<action:\w+>/<id:\d+>'=>'<controller>/<action>',
```

So, to ensure sanity, I just kept the following route definitions:

```
'<module:\w+>/<controller:\w+>/<action:\w+>'=>'<module>/<controller>/<action>',
'<controller:\w+>/<action:\w+>'=>'<controller>/<action>',
```

Hope this helps !
